### PR TITLE
Revert "fix(mobile): guard CollaborativeEditor render against null pairingData"

### DIFF
--- a/apps/mobile/components/__tests__/MobileHome.test.tsx
+++ b/apps/mobile/components/__tests__/MobileHome.test.tsx
@@ -7,4 +7,15 @@ describe('MobileHome', () => {
     const { toJSON } = render(<MobileHome />);
     expect(toJSON()).toBeTruthy();
   });
+
+  it('does not crash when isConnected is true but pairingData is null (Edit tab regression)', () => {
+    const mockProps = {
+      // Regression scenario: connection established but pairing data not yet populated.
+      isConnected: true,
+      pairingData: null,
+    } as any;
+
+    const { toJSON } = render(<MobileHome {...mockProps} />);
+    expect(toJSON()).toBeTruthy();
+  });
 });

--- a/apps/mobile/components/__tests__/MobileHome.test.tsx
+++ b/apps/mobile/components/__tests__/MobileHome.test.tsx
@@ -1,65 +1,10 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import MobileHome from '../MobileHome';
-import * as YjsFilesHook from '../../hooks/useYjsFiles';
-
-jest.mock('../../hooks/useYjsFiles', () => ({
-  useYjsFiles: jest.fn(() => ({
-    files: [],
-    isConnected: false,
-    error: null,
-    getFileContent: jest.fn(),
-  })),
-}));
-
-jest.mock('../../hooks/useDevicePairing', () => ({
-  useDevicePairing: jest.fn(() => ({
-    state: { status: 'idle' },
-    register: jest.fn(),
-    reset: jest.fn(),
-  })),
-}));
-
-// Lightweight stand-in so CollaborativeEditor doesn't attempt real Yjs/WS work
-jest.mock('../CollaborativeEditor', () => ({
-  CollaborativeEditor: () => null,
-}));
 
 describe('MobileHome', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    // Default: not connected, no pairingData
-    (YjsFilesHook.useYjsFiles as jest.Mock).mockReturnValue({
-      files: [],
-      isConnected: false,
-      error: null,
-      getFileContent: jest.fn(),
-    });
-  });
-
   it('renders without crashing', () => {
     const { toJSON } = render(<MobileHome />);
     expect(toJSON()).toBeTruthy();
-  });
-
-  it('shows "Not Connected" fallback on the Edit tab when isConnected is true but pairingData is null', () => {
-    // Simulate the race condition: WebSocket connected to default localhost
-    // before the user completes the pairing flow (pairingData remains null).
-    (YjsFilesHook.useYjsFiles as jest.Mock).mockReturnValue({
-      files: [],
-      isConnected: true,
-      error: null,
-      getFileContent: jest.fn(),
-    });
-
-    const { getByText, queryByTestId } = render(<MobileHome />);
-
-    // Navigate to the Edit tab
-    fireEvent.press(getByText('Edit'));
-
-    // The fallback "Not Connected" UI should be shown…
-    expect(getByText('Not Connected')).toBeTruthy();
-    // …and CollaborativeEditor must NOT have been rendered
-    expect(queryByTestId('collaborative-editor-root')).toBeNull();
   });
 });


### PR DESCRIPTION
This pull request simplifies the `MobileHome.test.tsx` test file by removing several mocked hooks and related test cases, leaving only a basic render test. This reduces test complexity and focuses the test suite on ensuring the component renders without errors.

Test cleanup and simplification:

* Removed all mocks for `useYjsFiles`, `useDevicePairing`, and `CollaborativeEditor`, as well as related setup and test cases, leaving only the basic render test for `MobileHome` (`MobileHome.test.tsx`).Reverts tbmobb813/United-Dev-Platform-#92